### PR TITLE
Fix turbo mode status check command

### DIFF
--- a/custom_components/panasonic_smart_app/switch.py
+++ b/custom_components/panasonic_smart_app/switch.py
@@ -266,7 +266,7 @@ class PanasonicACTurbo(PanasonicBaseEntity, SwitchEntity):
     @property
     def is_on(self) -> int:
         status = self.coordinator.data[self.index]["status"]
-        _turbo_status = status.get("0x1a", None)
+        _turbo_status = status.get("0x1A", None)
         if _turbo_status == None:
             return STATE_UNAVAILABLE
         _is_on = bool(int(_turbo_status))

--- a/custom_components/panasonic_smart_app/switch.py
+++ b/custom_components/panasonic_smart_app/switch.py
@@ -266,7 +266,7 @@ class PanasonicACTurbo(PanasonicBaseEntity, SwitchEntity):
     @property
     def is_on(self) -> int:
         status = self.coordinator.data[self.index]["status"]
-        _turbo_status = status.get("0x08", None)
+        _turbo_status = status.get("0x1a", None)
         if _turbo_status == None:
             return STATE_UNAVAILABLE
         _is_on = bool(int(_turbo_status))


### PR DESCRIPTION
I saw that the turbo mode status is wrong. Because although Turbo mode commandType is `0x1a` (and uses PanasonicACTurbo class when the commandType is `0x1a`), currently in the PanasonicACTurbo it checks `0x08`. `0x08` is nanoe commandType. I changed the command `0x08` to `0x1a` when checking whether turbo mode is on.

Device: CS-RX63GA2, CS-RX22GA2
Model: CZ-T006

Other features work great.