### PR TITLE
Fix sensor failed when device offline and improve async setup

### DIFF
--- a/custom_components/panasonic_smart_app/__init__.py
+++ b/custom_components/panasonic_smart_app/__init__.py
@@ -64,10 +64,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         DATA_COORDINATOR: coordinator,
     }
 
-    for platform in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
-        )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     entry.add_update_listener(async_reload_entry)
     return True

--- a/custom_components/panasonic_smart_app/sensor.py
+++ b/custom_components/panasonic_smart_app/sensor.py
@@ -53,7 +53,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> bool:
 
     for index, device in enumerate(devices):
         device_type = int(device.get("DeviceType"))
-        device_status = coordinator.data[index]["status"].keys()
+        device_status = coordinator.data[index].get("status", {}).keys()
         _LOGGER.debug(f"Device index #{index} status: {device_status}")
 
         sensors.append(


### PR DESCRIPTION
Fix #116 .
Improve async setup to prevent warning according to [Forwarding setup to config entry platforms](https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/)