### PR TITLE
Add support for refrigerator

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -49,39 +49,61 @@ _完整的實體清單請見 [可用的實體](#可用的實體)_
 
 ### 可用的實體
 
-| 裝置類型 | 實體類型      | 備註           |
-| -------- | ------------- | -------------- |
-| 冷氣     | climate       |                |
-|          | number        | 定時開機\*     |
-|          | number        | 定時關機       |
-|          | sensor        | 室外溫度偵測器 |
-|          | sensor        | PM2.5 偵測器\* |
-|          | switch        | nanoe 開關\*   |
-|          | switch        | ECONAVI 開關\* |
-|          | switch        | 操控聲音開關\* |
-|          | switch        | 急速模式開關\* |
-|          | switch        | 自體淨開關\*   |
-|          | switch        | 乾燥防霉開關\* |
-|          | switch        | 舒眠模式開關\* |
-|          | select        | 動向感應模式\* |
-|          | select        | 機體燈光模式\* |
-| 除濕機   | humidifier    |                |
-|          | number        | 定時開機\*     |
-|          | number        | 定時關機       |
-|          | select        | 風量設定       |
-|          | sensor        | 環境溼度偵測器 |
-|          | sensor        | PM2.5 偵測器\* |
-|          | binary_sensor | 水箱滿水偵測器 |
-| 洗衣機   | sensor        | 洗衣時間偵測器 |
-|          | sensor        | 運轉狀態偵測器 |
-|          | sensor        | 洗衣模式偵測器 |
-|          | sensor        | 洗衣行程偵測器 |
-| 空氣清淨機 | switch        | 電源開關     |
-|          | select        | 風量設定\*     |
-|          | switch        | nanoeX 開關\*  |
-|          | sensor        | PM2.5 偵測器   |
+| 裝置類型   | 實體類型      | 備註                       |
+| ---------- | ------------- | -------------------------- |
+| 通用       | sensor        | 用電量偵測器\*             |
+|            | sensor        | 碳排量偵測器\*             |
+| 冷氣       | climate       |                            |
+|            | number        | 定時開機\*                 |
+|            | number        | 定時關機                   |
+|            | sensor        | 室外溫度偵測器             |
+|            | sensor        | PM2.5 偵測器\*             |
+|            | switch        | nanoe 開關\*               |
+|            | switch        | ECONAVI 開關\*             |
+|            | switch        | 操控聲音開關\*             |
+|            | switch        | 急速模式開關\*             |
+|            | switch        | 自體淨開關\*               |
+|            | switch        | 乾燥防霉開關\*             |
+|            | switch        | 舒眠模式開關\*             |
+|            | select        | 動向感應模式\*             |
+|            | select        | 機體燈光模式\*             |
+| 除濕機     | humidifier    |                            |
+|            | number        | 定時開機\*                 |
+|            | number        | 定時關機                   |
+|            | select        | 風量設定                   |
+|            | sensor        | 環境溼度偵測器             |
+|            | sensor        | PM2.5 偵測器\*             |
+|            | binary_sensor | 水箱滿水偵測器             |
+| 洗衣機     | sensor        | 洗衣時間偵測器             |
+|            | sensor        | 運轉狀態偵測器             |
+|            | sensor        | 洗衣模式偵測器             |
+|            | sensor        | 洗衣行程偵測器             |
+| 空氣清淨機 | switch        | 電源開關                   |
+|            | select        | 風量設定\*                 |
+|            | switch        | nanoeX 開關\*              |
+|            | sensor        | PM2.5 偵測器               |
+| 電冰箱\**  | sensor        | 冷凍庫溫度偵測器           |
+|            | sensor        | 冰藏庫溫度偵測器           |
+|            | sensor        | 微凍結溫度偵測器           |
+|            | sensor        | 新鮮急凍結等級偵測器\*\*\* |
+|            | sensor        | 冬季模式偵測器\*\*\*       |
+|            | sensor        | 購物模式偵測器\*\*\*       |
+|            | sensor        | 假日模式偵測器\*\*\*       |
+|            | sensor        | 開門次數偵測器             |
+|            | select        | 冷凍庫溫度等級設定         |
+|            | select        | 冰藏庫溫度等級設定         |
+|            | select        | 微凍結溫度等級設定         |
+|            | select        | 製冰停止開關               |
+|            | select        | 快速製冰開關               |
+|            | binary_sensor | 除霜狀態偵測器             |
+|            | binary_sensor | ECONAVI 狀態偵測器         |
+|            | binary_sensor | nanoe 狀態偵測器           |
 
 \*僅在裝置支援的情況下可用
+
+\*\*只在 NR-D611XGS 上測試過
+
+\*\*\*這些設定可以在 Panasonic App 中調整，但目前在這個整合套件中是唯讀的
 
 註：請確保 Home Assistant 為最新版，否則部分實體可能無法使用
 

--- a/README.md
+++ b/README.md
@@ -51,39 +51,62 @@ See [支援的裝置 / Supported devices](https://github.com/osk2/panasonic_smar
 
 ### Available Entities
 
-| Device Type     | Entity Type   | Note                           |
-| --------------- | ------------- | ------------------------------ |
-| AC              | climate       |                                |
-|                 | number        | On timer\*                     |
-|                 | number        | Off timer                      |
-|                 | sensor        | Outdoor temperature sensor     |
-|                 | sensor        | PM2.5 sensor\*                 |
-|                 | switch        | nanoe switch\*                 |
-|                 | switch        | ECONAVI swtich\*               |
-|                 | switch        | Buzzer switch\*                |
-|                 | switch        | Turbo mode switch\*            |
-|                 | switch        | Self-clean mode switch\*       |
-|                 | switch        | Mold prevention switch\*       |
-|                 | switch        | Sleep mode switch\*            |
-|                 | select        | Motion detection mode select\* |
-|                 | select        | Indicator light select\*       |
-| Dehumidifier    | humidifier    |                                |
-|                 | number        | On timer\*                     |
-|                 | number        | Off timer                      |
-|                 | select        | Fan mode\*                     |
-|                 | sensor        | Environment humidity sensor    |
-|                 | sensor        | PM2.5 sensor\*                 |
-|                 | binary_sensor | Water tank status sensor       |
-| Washing Machine | sensor        | Countdown sensor               |
-|                 | sensor        | Device status sensor           |
-|                 | sensor        | Washing mode sensor            |
-|                 | sensor        | Washing cycle sensor           |
-| Purifier        | switch        | Power switch                   |
-|                 | select        | Fan level\*                    |
-|                 | switch        | nanoeX switch\*                |
-|                 | sensor        | PM2.5 sensor                   |
+| Device Type      | Entity Type   | Note                                     |
+| ---------------- | ------------- | ---------------------------------------- |
+| General          | sensor        | Energy consumption sensor\*              |
+|                  | sensor        | CO2 footprint sensor\*                   |
+| AC               | climate       |                                          |
+|                  | number        | On timer\*                               |
+|                  | number        | Off timer                                |
+|                  | sensor        | Outdoor temperature sensor               |
+|                  | sensor        | PM2.5 sensor\*                           |
+|                  | switch        | nanoe switch\*                           |
+|                  | switch        | ECONAVI swtich\*                         |
+|                  | switch        | Buzzer switch\*                          |
+|                  | switch        | Turbo mode switch\*                      |
+|                  | switch        | Self-clean mode switch\*                 |
+|                  | switch        | Mold prevention switch\*                 |
+|                  | switch        | Sleep mode switch\*                      |
+|                  | select        | Motion detection mode select\*           |
+|                  | select        | Indicator light select\*                 |
+| Dehumidifier     | humidifier    |                                          |
+|                  | number        | On timer\*                               |
+|                  | number        | Off timer                                |
+|                  | select        | Fan mode\*                               |
+|                  | sensor        | Environment humidity sensor              |
+|                  | sensor        | PM2.5 sensor\*                           |
+|                  | binary_sensor | Water tank status sensor                 |
+| Washing Machine  | sensor        | Countdown sensor                         |
+|                  | sensor        | Device status sensor                     |
+|                  | sensor        | Washing mode sensor                      |
+|                  | sensor        | Washing cycle sensor                     |
+| Purifier         | switch        | Power switch                             |
+|                  | select        | Fan level\*                              |
+|                  | switch        | nanoeX switch\*                          |
+|                  | sensor        | PM2.5 sensor                             |
+| Refrigerator\*\* | sensor        | Freezer temperature sensor               |
+|                  | sensor        | Refrigerator temperature sensor          |
+|                  | sensor        | Partial freezer temperature sensor       |
+|                  | sensor        | Rapid freezing level sensor\*\*\*        |
+|                  | sensor        | Winter mode sensor\*\*\*                 |
+|                  | sensor        | Shopping mode sensor\*\*\*               |
+|                  | sensor        | Vacation mode sensor\*\*\*               |
+|                  | sensor        | Door open count sensor                   |
+|                  | select        | Freezer temperature level select         |
+|                  | select        | Refrigerator temperature level select    |
+|                  | select        | Partial freezer temperature level select |
+|                  | switch        | Stop ice making switch                   |
+|                  | switch        | Quick ice making switch                  |
+|                  | binary_sensor | Defrosting status sensor                 |
+|                  | binary_sensor | ECONAVI status sensor                    |
+|                  | binary_sensor | nanoe status sensor                      |
+
 
 \*Only available if the feature is supported.
+
+\*\*Only tested with NR-D611XGS
+
+\*\*\*These settings should be configurable in the Panasonic App, but are currently read-only in this integration.
 
 Note: Ensure the latest Home Assistant is installed or some entities might not be available.
 

--- a/custom_components/panasonic_smart_app/binary_sensor.py
+++ b/custom_components/panasonic_smart_app/binary_sensor.py
@@ -1,16 +1,27 @@
-from datetime import timedelta
 import logging
-from homeassistant.components.binary_sensor import BinarySensorEntity
+from abc import ABC, abstractmethod
 
-from .entity import PanasonicBaseEntity
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorDeviceClass,
+)
+
 from .const import (
-    DOMAIN,
-    DEVICE_TYPE_DEHUMIDIFIER,
     DATA_CLIENT,
     DATA_COORDINATOR,
-    LABEL_TANK,
+    DEVICE_TYPE_DEHUMIDIFIER,
+    DEVICE_TYPE_REFRIGERATOR,
+    DOMAIN,
+    ICON_DEFROSTING,
     ICON_TANK,
+    ICON_ECONAVI,
+    ICON_NANOE,
+    LABEL_REFRIGERATOR_DEFROSTING_STATUS,
+    LABEL_TANK,
+    LABEL_ECONAVI,
+    LABEL_NANOE,
 )
+from .entity import PanasonicBaseEntity
 
 _LOGGER = logging.getLogger(__package__)
 
@@ -22,7 +33,9 @@ async def async_setup_entry(hass, entry, async_add_entities) -> bool:
     sensors = []
 
     for index, device in enumerate(devices):
-        if int(device.get("DeviceType")) == DEVICE_TYPE_DEHUMIDIFIER:
+        device_type = int(device.get("DeviceType"))
+
+        if device_type == DEVICE_TYPE_DEHUMIDIFIER:
             sensors.append(
                 PanasonoicTankSensor(
                     coordinator,
@@ -31,6 +44,21 @@ async def async_setup_entry(hass, entry, async_add_entities) -> bool:
                     device,
                 )
             )
+        elif device_type == DEVICE_TYPE_REFRIGERATOR:
+            for sensor_type in (
+                PanasonicRefrigeratorDefrostSensor,
+                PanasonicRefrigeratorEcoSensor,
+                PanasonicRefrigeratorNanoeSensor,
+            ):
+                if sensor_type.command_type in device["status"]:
+                    sensors.append(
+                        sensor_type(
+                            coordinator,
+                            index,
+                            client,
+                            device,
+                        )
+                    )
 
     async_add_entities(sensors, True)
 
@@ -59,3 +87,69 @@ class PanasonoicTankSensor(PanasonicBaseEntity, BinarySensorEntity):
         _is_tank_full = bool(int(status.get("0x0A", 0)))
         _LOGGER.debug(f"[{self.label}] is_on: {_is_tank_full}")
         return _is_tank_full
+
+
+class PanasonicRefrigeratorBinarySensorABC(
+    PanasonicBaseEntity, BinarySensorEntity, ABC
+):
+    """Abstract class for binary sensor of Panasonic refrigerator."""
+
+    @property
+    @abstractmethod
+    def icon(self) -> str:
+        """Icon of binary sensor."""
+
+    @property
+    @abstractmethod
+    def command_name(self) -> str:
+        """Command name from the Panasonic API."""
+
+    @property
+    @abstractmethod
+    def command_type(self) -> str:
+        """Command type from the Panasonic API."""
+
+    @property
+    def label(self) -> str:
+        return f"{self.nickname} {self.command_name}"
+
+    @property
+    def is_on(self) -> bool | None:
+        status = self.coordinator.data[self.index]["status"]
+
+        try:
+            _is_on = int(status[self.command_type]) == 1
+        except (KeyError, ValueError):
+            _LOGGER.exception(f"Error while getting status for {self.label}")
+            return None
+
+        _LOGGER.debug(f"[{self.label}] is_on: {_is_on}")
+
+        return _is_on
+
+
+class PanasonicRefrigeratorDefrostSensor(PanasonicRefrigeratorBinarySensorABC):
+    """Defrosting status of Panasonic refrigerator."""
+
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+    command_name = LABEL_REFRIGERATOR_DEFROSTING_STATUS
+    command_type = "0x50"
+    icon = ICON_DEFROSTING
+
+
+class PanasonicRefrigeratorEcoSensor(PanasonicRefrigeratorBinarySensorABC):
+    """ECO status of Panasonic refrigerator."""
+
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+    command_name = LABEL_ECONAVI
+    command_type = "0x0C"
+    icon = ICON_ECONAVI
+
+
+class PanasonicRefrigeratorNanoeSensor(PanasonicRefrigeratorBinarySensorABC):
+    """nanoe status of Panasonic refrigerator."""
+
+    _attr_device_class = BinarySensorDeviceClass.RUNNING
+    command_name = LABEL_NANOE
+    command_type = "0x61"
+    icon = ICON_NANOE

--- a/custom_components/panasonic_smart_app/const.py
+++ b/custom_components/panasonic_smart_app/const.py
@@ -16,6 +16,7 @@ MANUFACTURER = "Panasonic"
 DEFAULT_NAME = "Panasonic Smart Application"
 
 DEVICE_TYPE_AC = 1
+DEVICE_TYPE_REFRIGERATOR = 2
 DEVICE_TYPE_WASHING_MACHINE = 3
 DEVICE_TYPE_DEHUMIDIFIER = 4
 DEVICE_TYPE_PURIFIER = 8
@@ -54,6 +55,23 @@ DEVICE_STATUS_CODES = {
         "0x1F",  # AC indicator light
         "0x37",  # AC PM2.5
     ],
+    DEVICE_TYPE_REFRIGERATOR: [
+        "0x00",  # Refrigerator freezer temperature setting
+        "0x01",  # Refrigerator refrigerator temperature setting
+        "0x57",  # Refrigerator partial freezing temperature setting
+        "0x03",  # Refrigerator freezer temperature display
+        "0x05",  # Refrigerator refrigerator temperature display
+        "0x58",  # Refrigerator partial freezing temperature display
+        "0x50",  # Refrigerator defrosting status
+        "0x0C",  # Refrigerator ECO status
+        "0x61",  # Refrigerator nanoe status
+        "0x52",  # Refrigerator stop ice making status
+        "0x53",  # Refrigerator quick ice making status
+        "0x56",  # Refrigerator rapid freezing status
+        "0x5A",  # Refrigerator winter mode
+        "0x5B",  # Refrigerator shopping mode
+        "0x5C",  # Refrigerator vacation mode
+    ],
     DEVICE_TYPE_DEHUMIDIFIER: [
         "0x00",  # Dehumidifier power status
         "0x01",  # Dehumidifier operation mode
@@ -70,15 +88,15 @@ DEVICE_STATUS_CODES = {
         "0x0E",  # Dehumidifier fan mode
     ],
     DEVICE_TYPE_WASHING_MACHINE: [
-        "0x13", # Washing machine remaining washing time
-        "0x14", # Washing machine timer
-        "0x15", # Washing machine remaining time to trigger timer
-        "0x41", # Washing machine timer for japan model
-        "0x50", # Washing machine status
-        "0x54", # Washing machine current mode
-        "0x55", # Washing machine current cycle
-        "0x61", # Washing machine dryer delay
-        "0x64", # Washing machine cycle
+        "0x13",  # Washing machine remaining washing time
+        "0x14",  # Washing machine timer
+        "0x15",  # Washing machine remaining time to trigger timer
+        "0x41",  # Washing machine timer for japan model
+        "0x50",  # Washing machine status
+        "0x54",  # Washing machine current mode
+        "0x55",  # Washing machine current cycle
+        "0x61",  # Washing machine dryer delay
+        "0x64",  # Washing machine cycle
     ],
     DEVICE_TYPE_PURIFIER: [
         "0x00",  # Purifier power status
@@ -142,6 +160,7 @@ ICON_BUZZER = "mdi:volume-high"
 ICON_TURBO = "mdi:clock-fast"
 ICON_FAN = "mdi:fan"
 ICON_ENERGY = "mdi:flash"
+ICON_REFRIGERATOR = "mdi:fridge"
 ICON_MOLD_PREVENTION = "mdi:weather-windy"
 ICON_SLEEP = "mdi:sleep"
 ICON_CLEAN = "mdi:broom"
@@ -154,6 +173,18 @@ ICON_WASHING_MACHINE = "mdi:washing-machine"
 ICON_LIST = "mdi:order-bool-descending-variant"
 ICON_PURIFIER = "mdi:air-purifier"
 ICON_BUZZER = "mdi:volume-high"
+ICON_DEFROSTING = "mdi:car-defrost-rear"
+ICON_STOP_ICE_MAKING = "mdi:snowflake-off"
+ICON_QUICK_ICE_MAKING = "mdi:snowflake-variant"
+ICON_REFRIGERATOR_FREEZER = "mdi:snowflake"
+ICON_REFRIGERATOR_REFRIGERATOR = "mdi:fridge"
+ICON_REFRIGERATOR_PARTIAL_FREEZING = "mdi:food-steak"
+ICON_REFRIGERATOR_RAPID_FREEZING = "mdi:snowflake-alert"
+ICON_REFRIGERATOR_WINTER_MODE = "mdi:snowflake"
+ICON_REFRIGERATOR_SHOPPING_MODE = "mdi:cart"
+ICON_REFRIGERATOR_VACATION_MODE = "mdi:beach"
+
+ICON_CO2_FOOTPRINT = "mdi:molecule-co2"
 
 LABEL_DEHUMIDIFIER = ""
 LABEL_CLIMATE = ""
@@ -177,6 +208,13 @@ LABEL_WASHING_MACHINE_COUNTDOWN = "剩餘洗衣時間"
 LABEL_WASHING_MACHINE_STATUS = "運轉狀態"
 LABEL_WASHING_MACHINE_CYCLE = "目前行程"
 LABEL_WASHING_MACHINE_MODE = "目前模式"
+LABEL_REFRIGERATOR_FREEZER_TEMPERATURE_DISPLAY = "冷凍溫度"
+LABEL_REFRIGERATOR_REFRIGERATOR_TEMPERATURE_DISPLAY = "冷藏溫度"
+LABEL_REFRIGERATOR_PARTIAL_FREEZING_TEMPERATURE_DISPLAY = "微凍結溫度"
+LABEL_REFRIGERATOR_DEFROSTING_STATUS = "除霜中"
+LABEL_REFRIGERATOR_STOP_ICE_MAKING = "製冰停止"
+LABEL_REFRIGERATOR_QUICK_ICE_MAKING = "快速製冰"
+LABEL_REFRIGERATOR_RAPID_FREEZING_STATUS = "新鮮急凍結"
 LABEL_OUTDOOR_TEMPERATURE = "室外溫度"
 LABEL_PURIFIER_FAN_LEVEL = "風量設定"
 LABEL_PM25 = "PM2.5"
@@ -186,6 +224,8 @@ LABEL_ECONAVI = "ECONAVI"
 LABEL_BUZZER = "操作提示音"
 LABEL_TURBO = "急速"
 LABEL_ENERGY = "本月耗電量"
+LABEL_REFRIGERATOR_OPEN_DOOR = "本月開門次數"
+LABEL_CO2_FOOTPRINT = "本月碳排放"
 LABEL_POWER = "電源"
 
 UNIT_HOUR = "小時"

--- a/custom_components/panasonic_smart_app/entity.py
+++ b/custom_components/panasonic_smart_app/entity.py
@@ -1,11 +1,10 @@
-from datetime import timedelta
 from abc import ABC, abstractmethod
+
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    DOMAIN,
-    MANUFACTURER,
-)
+from .const import DOMAIN, MANUFACTURER
+from .smartApp import SmartApp
+
 
 class PanasonicBaseEntity(CoordinatorEntity, ABC):
     def __init__(
@@ -16,7 +15,7 @@ class PanasonicBaseEntity(CoordinatorEntity, ABC):
         device,
     ):
         super().__init__(coordinator)
-        self.client = client
+        self.client: SmartApp = client
         self.device = device
         self.index = index
 

--- a/custom_components/panasonic_smart_app/select.py
+++ b/custom_components/panasonic_smart_app/select.py
@@ -1,10 +1,14 @@
 import logging
+from abc import ABC, abstractmethod
+
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.components.select import SelectEntity
 
 from .entity import PanasonicBaseEntity
 from .const import (
     DOMAIN,
     DEVICE_TYPE_AC,
+    DEVICE_TYPE_REFRIGERATOR,
     DEVICE_TYPE_DEHUMIDIFIER,
     DEVICE_TYPE_PURIFIER,
     DATA_CLIENT,
@@ -12,13 +16,14 @@ from .const import (
     LABEL_DEHUMIDIFIER_FAN_MODE,
     LABEL_DEHUMIDIFIER_FAN_POSITION,
     LABEL_PURIFIER_FAN_LEVEL,
-    LABEL_CLIMATE_FAN_POSITION,
     LABEL_CLIMATE_MOTION_DETECTION,
     LABEL_CLIMATE_INDICATOR,
     ICON_FAN,
     ICON_LIGHT,
     ICON_MOTION_SENSOR,
-    ICON_HUMIDITY,
+    ICON_REFRIGERATOR_FREEZER,
+    ICON_REFRIGERATOR_REFRIGERATOR,
+    ICON_REFRIGERATOR_PARTIAL_FREEZING,
 )
 
 _LOGGER = logging.getLogger(__package__)
@@ -62,7 +67,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> bool:
                         client,
                         device,
                     )
-                )       
+                )
 
         if device_type == DEVICE_TYPE_AC:
 
@@ -84,6 +89,22 @@ async def async_setup_entry(hass, entry, async_add_entities) -> bool:
                         device,
                     )
                 )
+
+        if device_type == DEVICE_TYPE_REFRIGERATOR:
+            for select_type in (
+                PanasonicRefrigeratorFreezerTemperatureSelect,
+                PanasonicRefrigeratorRefrigeratorTemperatureSelect,
+                PanasonicRefrigeratorPartialFreezingTemperatureSelect,
+            ):
+                if select_type.command_type in device["status"]:
+                    select.append(
+                        select_type(
+                            coordinator,
+                            index,
+                            client,
+                            device,
+                        )
+                    )
 
         if device_type == DEVICE_TYPE_PURIFIER:
             if "0x01" in command_types:
@@ -153,6 +174,7 @@ class PanasonoicDehumidifierFanModeSelect(PanasonicBaseEntity, SelectEntity):
         else:
             return
 
+
 class PanasonoicDehumidifierFanPositionSelect(PanasonicBaseEntity, SelectEntity):
     @property
     def available(self) -> bool:
@@ -204,6 +226,7 @@ class PanasonoicDehumidifierFanPositionSelect(PanasonicBaseEntity, SelectEntity)
             await self.coordinator.async_request_refresh()
         else:
             return
+
 
 class PanasonoicACMotionDetection(PanasonicBaseEntity, SelectEntity):
     @property
@@ -365,3 +388,97 @@ class PanasonoicPurifierFanLevelSelect(PanasonicBaseEntity, SelectEntity):
             await self.coordinator.async_request_refresh()
         else:
             return
+
+
+class PanasonoicRefrigeratorTemperatureSelectABC(PanasonicBaseEntity, SelectEntity, ABC):
+    """Abstract class for select entity of Panasonic refrigerator temperature setting."""
+
+    @property
+    @abstractmethod
+    def icon(self) -> str:
+        """Icon of this entity."""
+
+    @property
+    @abstractmethod
+    def command_type(self) -> str:
+        """
+        Command type from Panasonic UserGetRegisteredGwList2 API. Used to get and set
+        the status.
+        """
+
+    def _this_command(self) -> dict:
+        """The corresponding command of this entity in Panasonic UserGetRegisteredGwList2 API."""
+        for command in self.commands:
+            if command["CommandType"] == self.command_type:
+                return command
+
+        raise HomeAssistantError(
+            f"Command not found in commands: {self.command_type} for {self.label}"
+        )
+
+    @property
+    def label(self) -> str:
+        command_name = self._this_command()["CommandName"]
+        return f"{self.nickname} {command_name}"
+
+    @property
+    def current_option(self) -> str | None:
+        status = self.coordinator.data[self.index]["status"]
+
+        try:
+            value = int(status[self.command_type])
+        except (KeyError, ValueError):
+            _LOGGER.exception(f"Error while getting status for {self.label}")
+            return None
+
+        for parameter in self._this_command()["Parameters"]:
+            if parameter[1] == value:
+                _LOGGER.debug(f"[{self.label}] current_option: {parameter[0]}")
+                return parameter[0]
+
+        _LOGGER.error(f"Unknown value {value} for {self.label}")
+        return None
+
+    @property
+    def options(self) -> list[str]:
+        return [
+            parameter[0]
+            for parameter in self._this_command()["Parameters"]
+        ]
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        _LOGGER.debug(f"[{self.label}] Set temperature to {option}")
+
+        for parameter in self._this_command()["Parameters"]:
+            if parameter[0] == option:
+                await self.client.set_command(
+                    deviceId=self.auth,
+                    command=int(self.command_type, 16),
+                    value=parameter[1],
+                )
+                await self.coordinator.async_request_refresh()
+                return
+
+        _LOGGER.error(f"Unknown option {option} for {self.label}")
+
+
+class PanasonicRefrigeratorFreezerTemperatureSelect(PanasonoicRefrigeratorTemperatureSelectABC):
+    """Select entity for Panasonic refrigerator freezer temperature setting."""
+
+    icon = ICON_REFRIGERATOR_FREEZER
+    command_type = "0x00"
+
+
+class PanasonicRefrigeratorRefrigeratorTemperatureSelect(PanasonoicRefrigeratorTemperatureSelectABC):
+    """Select entity for Panasonic refrigerator refrigerator temperature setting."""
+
+    icon = ICON_REFRIGERATOR_REFRIGERATOR
+    command_type = "0x01"
+
+
+class PanasonicRefrigeratorPartialFreezingTemperatureSelect(PanasonoicRefrigeratorTemperatureSelectABC):
+    """Select entity for Panasonic refrigerator partial freezing temperature setting."""
+
+    icon = ICON_REFRIGERATOR_PARTIAL_FREEZING
+    command_type = "0x57"

--- a/custom_components/panasonic_smart_app/smartApp/urls.py
+++ b/custom_components/panasonic_smart_app/smartApp/urls.py
@@ -18,7 +18,7 @@ def get_device_info():
     return url
 
 
-def get_energy_report():
+def get_info():
     url = f"{BASE_URL}/UserGetInfo"
     return url
 


### PR DESCRIPTION
## Add support for refrigerator

Add entities for refrigerator, such as temperatures and defrosting status. Some settings should be configurable in the Panasonic App, but are currently read-only in this commit due the complexity. 

Theseare only tested with a Panasonic NR-D611XGS refrigerator, and might not work with other models.

Also add a CO2 footprint sensor that might be available for other appliances, which is similar to the energy consumption sensor.

Please note that the number of API calls will increase by two per refresh due to the addition of `get_info()` for `co2` and `Ref_OpenDoor_Total`. To avoid exceeding API rate limits, ensure the refresh interval is sufficiently low.

---

新增冰箱的各種 entity，例如溫度和除霜狀態。有些選項本來可以在 Panasonic 的 App 中設定，但因為比較複雜，先寫成唯讀。

這些都只有 Panasonic NR-D611XGS 上測試過，其它型號不確定能不能用。

另外也加了一個 CO2 排放量的 entiry，有點像本來就有的 energy report，可能其它電器也能用？

要注意由於加上了拿 CO2 排放量和冰箱開門次數的 `get_info()`，每次更新的 API call 會多兩次。確認設定的更新時間間隔不會撞到 API request 的次數限制。

---

![圖片](https://github.com/user-attachments/assets/5cad37cf-87e4-4ca8-bd05-1bf8f749fd2a)
